### PR TITLE
Minor code comment tidy

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -1321,7 +1321,7 @@ function civicrm_modules_enabled($modules) {
 }
 
 /**
- * Implementation of hook_modules_disabled().
+ * Implements hook_modules_disabled().
  */
 function civicrm_modules_disabled($modules) {
   civicrm_initialize();
@@ -1337,12 +1337,12 @@ function civicrm_modules_uninstalled($modules) {
 }
 
 /**
- * Implements hook__metatag_page_cache_cid_parts_alter().
+ * Implements hook_metatag_page_cache_cid_parts_alter().
  *
- * Append the query string to the key under which the page title is cached to prevent cross-contamination
- * from urls such as civicrm/contribute/transact.
+ * Append the query string to the key under which the page title is cached to
+ * prevent cross-contamination from URLs such as civicrm/contribute/transact.
  *
- * If metadata module is not installed this function will not fire.
+ * If the metatag module is not installed this function will not fire.
  *
  * @param array $cid_parts
  */


### PR DESCRIPTION
Remove the last instance of 'implementation of' and tidy up comments for the metatag hook.
